### PR TITLE
Fix std::filesystem::path in fmt::format

### DIFF
--- a/common/include/cvs/common/config.hpp
+++ b/common/include/cvs/common/config.hpp
@@ -298,12 +298,12 @@ struct CVSConfig : public CVSConfigBase {
     }
   }
 
-  static CVSOutcome<Self> make(const std::filesystem::path& filename) noexcept {
+  static CVSOutcome<Self> make(const std::filesystem::path& filepath) noexcept {
     try {
-      return make(load(filename));
+      return make(load(filepath));
     }
     catch (...) {
-      CVS_RETURN_WITH_NESTED(std::runtime_error(fmt::format("Can't parse config from file {}.", filename)));
+      CVS_RETURN_WITH_NESTED(std::runtime_error(fmt::format("Can't parse config from file {}.", filepath.string())));
     }
   }
 


### PR DESCRIPTION
fmt версии 6 не понимает тип std::filesystem::path